### PR TITLE
dependabot isolation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,22 @@ updates:
     interval: daily
   allow:
     - dependency-type: direct
+  ignore:
+    - dependency-name: "@gar/npm-registry-test"
   versioning-strategy: increase-if-necessary
   commit-message:
     prefix: deps
     prefix-development: chore
+  labels:
+    - "dependencies"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  allow:
+    - dependency-name: "@gar/npm-registry-test"
+  versioning-strategy: increase
+  commit-message:
+    prefix: chore
   labels:
     - "dependencies"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   },
   "author": "Gar <gar+npm@danger.computer>",
   "license": "ISC",
-  "devDependencies": {
-    "@commitlint/cli": "^15.0.0",
-    "@commitlint/config-conventional": "^15.0.0",
-    "conventional-release": "^1.0.2"
+  "dependencies": {
+    "@gar/npm-registry-test": "^1.0.0"
   }
 }


### PR DESCRIPTION
- deps: add @gar/npm-registry-test
- chore: isolate a dep for dependabot
